### PR TITLE
Solve issue "Caused by: java.lang.ClassNotFoundException: io.micromet…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<keycloak.version>20.0.3</keycloak.version>
 		<infinispan.version>14.0.4.Final</infinispan.version>
 		<resteasy.version>4.7.7.Final</resteasy.version>
+		<micrometer.version>1.10.3</micrometer.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -38,6 +39,13 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<version>${micrometer.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>


### PR DESCRIPTION
When I tried to start it on MacBook 2019 (MacOS monterey) with OpenJDK 17, it cause a `ClassNotFoundException` error.

After adding dependency `micrometer-registry-prometheus`, the issue solved.

Following are the error details:

```shell
# Other logs...

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2023-02-13 14:24:02.138 ERROR 96620 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.context.ApplicationContextException: Failed to start bean 'webServerStartStop'; nested exception is org.springframework.boot.web.server.WebServerException: Unable to start embedded Tomcat server
	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:181) ~[spring-context-5.3.24.jar:5.3.24]
	at org.springframework.context.support.DefaultLifecycleProcessor.access$200(DefaultLifecycleProcessor.java:54) ~[spring-context-5.3.24.jar:5.3.24]
	at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:356) ~[spring-context-5.3.24.jar:5.3.24]
	at java.base/java.lang.Iterable.forEach(Iterable.java:75) ~[na:na]
	at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:155) ~[spring-context-5.3.24.jar:5.3.24]
	at org.springframework.context.support.DefaultLifecycleProcessor.onRefresh(DefaultLifecycleProcessor.java:123) ~[spring-context-5.3.24.jar:5.3.24]
	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:935) ~[spring-context-5.3.24.jar:5.3.24]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:586) ~[spring-context-5.3.24.jar:5.3.24]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:147) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:731) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1303) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1292) ~[spring-boot-2.7.7.jar:2.7.7]
	at com.suchorski.server.SpringbootKeycloakServerApplication.main(SpringbootKeycloakServerApplication.java:15) ~[classes/:na]
Caused by: org.springframework.boot.web.server.WebServerException: Unable to start embedded Tomcat server
	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:229) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.web.servlet.context.WebServerStartStopLifecycle.start(WebServerStartStopLifecycle.java:43) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:178) ~[spring-context-5.3.24.jar:5.3.24]
	... 14 common frames omitted
Caused by: org.springframework.boot.web.server.WebServerException: Servlet [httpServlet30Dispatcher] in web application [] threw load() exception
	at org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedContext.load(TomcatEmbeddedContext.java:86) ~[spring-boot-2.7.7.jar:2.7.7]
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[na:na]
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276) ~[na:na]
	at java.base/java.util.TreeMap$ValueSpliterator.forEachRemaining(TreeMap.java:3215) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[na:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[na:na]
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[na:na]
	at org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedContext.lambda$deferredLoadOnStartup$0(TomcatEmbeddedContext.java:64) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedContext.doWithThreadContextClassLoader(TomcatEmbeddedContext.java:105) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedContext.deferredLoadOnStartup(TomcatEmbeddedContext.java:63) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.performDeferredLoadOnStartup(TomcatWebServer.java:305) ~[spring-boot-2.7.7.jar:2.7.7]
	at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:216) ~[spring-boot-2.7.7.jar:2.7.7]
	... 16 common frames omitted
Caused by: javax.servlet.ServletException: Servlet.init() for servlet [httpServlet30Dispatcher] threw exception
	at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:1178) ~[tomcat-embed-core-9.0.70.jar:9.0.70]
	at org.apache.catalina.core.StandardWrapper.load(StandardWrapper.java:1010) ~[tomcat-embed-core-9.0.70.jar:9.0.70]
	at org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedContext.load(TomcatEmbeddedContext.java:81) ~[spring-boot-2.7.7.jar:2.7.7]
	... 32 common frames omitted
Caused by: java.lang.RuntimeException: RESTEASY003325: Failed to construct public com.suchorski.server.keycloak.App()
	at org.jboss.resteasy.core.ConstructorInjectorImpl.constructOutsideRequest(ConstructorInjectorImpl.java:250) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.ConstructorInjectorImpl.construct(ConstructorInjectorImpl.java:209) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.providerfactory.Utils.createProviderInstance(Utils.java:102) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl.createProviderInstance(ResteasyProviderFactoryImpl.java:1385) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.ResteasyDeploymentImpl.createApplication(ResteasyDeploymentImpl.java:418) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.ResteasyDeploymentImpl.initializeObjects(ResteasyDeploymentImpl.java:265) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.ResteasyDeploymentImpl.startInternal(ResteasyDeploymentImpl.java:137) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.core.ResteasyDeploymentImpl.start(ResteasyDeploymentImpl.java:121) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.init(ServletContainerDispatcher.java:144) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.init(HttpServletDispatcher.java:42) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:1161) ~[tomcat-embed-core-9.0.70.jar:9.0.70]
	... 34 common frames omitted
Caused by: java.lang.RuntimeException: org.infinispan.manager.EmbeddedCacheManagerStartupException: org.infinispan.commons.CacheConfigurationException: ISPN000659: Component org.infinispan.metrics.impl.MetricsCollector failed to start
	at com.suchorski.server.keycloak.providers.SimplePlatformProvider.exit(SimplePlatformProvider.java:27) ~[classes/:na]
	at org.keycloak.services.resources.KeycloakApplication.<init>(KeycloakApplication.java:124) ~[keycloak-services-20.0.3.jar:20.0.3]
	at com.suchorski.server.keycloak.App.<init>(App.java:17) ~[classes/:na]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[na:na]
	at org.jboss.resteasy.core.ConstructorInjectorImpl.constructOutsideRequest(ConstructorInjectorImpl.java:225) ~[resteasy-core-4.7.7.Final.jar:4.7.7.Final]
	... 44 common frames omitted
Caused by: org.infinispan.manager.EmbeddedCacheManagerStartupException: org.infinispan.commons.CacheConfigurationException: ISPN000659: Component org.infinispan.metrics.impl.MetricsCollector failed to start
	at org.infinispan.manager.DefaultCacheManager.internalStart(DefaultCacheManager.java:778) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.manager.DefaultCacheManager.start(DefaultCacheManager.java:742) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.manager.DefaultCacheManager.<init>(DefaultCacheManager.java:303) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.manager.DefaultCacheManager.<init>(DefaultCacheManager.java:225) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory.initEmbedded(DefaultInfinispanConnectionProviderFactory.java:224) ~[keycloak-model-infinispan-20.0.3.jar:20.0.3]
	at org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory.lazyInit(DefaultInfinispanConnectionProviderFactory.java:150) ~[keycloak-model-infinispan-20.0.3.jar:20.0.3]
	at org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory.create(DefaultInfinispanConnectionProviderFactory.java:83) ~[keycloak-model-infinispan-20.0.3.jar:20.0.3]
	at org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory.create(DefaultInfinispanConnectionProviderFactory.java:67) ~[keycloak-model-infinispan-20.0.3.jar:20.0.3]
	at org.keycloak.services.DefaultKeycloakSession.getProvider(DefaultKeycloakSession.java:265) ~[keycloak-services-20.0.3.jar:20.0.3]
	at org.keycloak.models.sessions.infinispan.InfinispanSingleUseObjectProviderFactory.getSingleUseObjectCache(InfinispanSingleUseObjectProviderFactory.java:53) ~[keycloak-model-infinispan-20.0.3.jar:20.0.3]
	at org.keycloak.models.sessions.infinispan.InfinispanSingleUseObjectProviderFactory.postInit(InfinispanSingleUseObjectProviderFactory.java:77) ~[keycloak-model-infinispan-20.0.3.jar:20.0.3]
	at org.keycloak.services.DefaultKeycloakSessionFactory.init(DefaultKeycloakSessionFactory.java:129) ~[keycloak-services-20.0.3.jar:20.0.3]
	at org.keycloak.services.resources.KeycloakApplication.createSessionFactory(KeycloakApplication.java:237) ~[keycloak-services-20.0.3.jar:20.0.3]
	at org.keycloak.services.resources.KeycloakApplication.startup(KeycloakApplication.java:130) ~[keycloak-services-20.0.3.jar:20.0.3]
	at com.suchorski.server.keycloak.providers.SimplePlatformProvider.onStartup(SimplePlatformProvider.java:19) ~[classes/:na]
	at org.keycloak.services.resources.KeycloakApplication.<init>(KeycloakApplication.java:120) ~[keycloak-services-20.0.3.jar:20.0.3]
	... 51 common frames omitted
Caused by: org.infinispan.commons.CacheConfigurationException: ISPN000659: Component org.infinispan.metrics.impl.MetricsCollector failed to start
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:585) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:808) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startDependencies(BasicComponentRegistryImpl.java:635) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:599) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:577) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:808) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.AbstractComponentRegistry.internalStart(AbstractComponentRegistry.java:357) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.AbstractComponentRegistry.start(AbstractComponentRegistry.java:250) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.manager.DefaultCacheManager.internalStart(DefaultCacheManager.java:774) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	... 66 common frames omitted
Caused by: java.lang.NoClassDefFoundError: io/micrometer/prometheus/PrometheusMeterRegistry
	at org.infinispan.metrics.impl.MetricsCollector.createMeterRegistry(MetricsCollector.java:224) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.metrics.impl.MetricsCollector.start(MetricsCollector.java:74) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.metrics.impl.CorePackageImpl$1.start(CorePackageImpl.java:41) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.metrics.impl.CorePackageImpl$1.start(CorePackageImpl.java:34) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.invokeStart(BasicComponentRegistryImpl.java:617) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:608) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:577) ~[infinispan-core-14.0.4.Final.jar:14.0.4.Final]
	... 74 common frames omitted
Caused by: java.lang.ClassNotFoundException: io.micrometer.prometheus.PrometheusMeterRegistry
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[na:na]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[na:na]
	... 81 common frames omitted

````