### PR TITLE
5.0.0 throwing errors on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ _Based on this post from [Baeldung](https://www.baeldung.com/keycloak-embedded-i
 | - | - | - | - | - | - | - |
 | 4.0.0 | 17 | 22.0.5 | 3.1.5 | 6.2.4.Final | 14.0.19.Final | 4.23.2 |
 | 5.0.0 | 17 | 23.0.3 | 3.2.0 | 6.2.4.Final | 14.0.21.Final | 4.23.2 |
+| 5.0.1 | 17 | 23.0.4 | 3.2.1 | 6.2.4.Final | 14.0.21.Final | 4.23.2 |
 
 * Removed older versions from compatibility table keeping last 2 major version. For olders, check the [tags](https://github.com/suchorski/springboot-keycloak-server/tags) section.
 
@@ -30,7 +31,7 @@ You can clone this repo and build it using the [Maven](https://maven.apache.org/
 $ git clone https://github.com/suchorski/springboot-keycloak-server
 $ cd springboot-keycloak-server
 $ mvn package
-$ java -jar target/server-5.0.0.jar
+$ java -jar target/server-5.0.1.jar
 ```
 
 # Contribution

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.1</version>
 		<relativePath />
 	</parent>
 	<groupId>com.suchorski</groupId>
@@ -30,10 +30,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -83,8 +79,6 @@
 			<artifactId>resteasy-client</artifactId>
 			<version>${resteasy.version}</version>
 		</dependency>
-
-
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jackson2-provider</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.suchorski</groupId>
 	<artifactId>server</artifactId>
-	<version>5.0.0</version>
+	<version>5.0.1</version>
 	<name>springboot-keycloak-server</name>
 	<description>Embeded Keycloak on Spring Boot Server</description>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<description>Embeded Keycloak on Spring Boot Server</description>
 	<properties>
 		<java.version>17</java.version>
-		<keycloak.version>23.0.3</keycloak.version>
+		<keycloak.version>23.0.4</keycloak.version>
 		<infinispan.version>14.0.21.Final</infinispan.version>
 		<resteasy.version>6.2.4.Final</resteasy.version>
 		<micrometer.version>1.10.3</micrometer.version>


### PR DESCRIPTION
5.0.0 throwing errors on startup.  Removing spring-boot-starter-actuator fixed startup issue.
Updated Spring Boot and Keycloak